### PR TITLE
Fix misnamed MwUser.config

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -38,7 +38,7 @@ interface MwStorage {
 }
 
 interface MwUser {
-	config: {
+	options: {
 		get( configKey: string|null, fallback?: any|null ): string;
 		set( configKey: string|null, value: any|null ): void;
 	},


### PR DESCRIPTION
mw.user.config does not exist, assuming this was meant to refer to mw.user.options