### PR TITLE
Clean up of mw.util.getUrl

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -72,11 +72,10 @@ interface MediaWiki {
 		 */
 		getParamValue( param: string ): string
 		/**
-		 *
 		 * @param pageName
 		 * @param params
 		 */
-	getUrl(pageName?: string, params?: Object): string;
+		getUrl(pageName?: string, params?: Object): string;
 		/**
 		 * @param {string} id of portlet
 		 */


### PR DESCRIPTION
Add missing tab, I must have missed it earlier
Also remove an empty line in the documentation block