### PR TITLE
mw.user.getId() returns a Number

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -44,7 +44,7 @@ interface MwUser {
 	},
 	id(): string;
 	getGroups( callback: Function ): JQuery.Promise<any>;
-	getId(): string;
+	getId(): Number;
 	getName(): string;
 	isAnon(): boolean;
 	generateRandomSessionId(): string;


### PR DESCRIPTION
Fix the documentation from "string" to "Number", it returns the user's id (or 0 for anonymous users).