### PR TITLE
Update interface mwHookInstance with fire property

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -37,6 +37,7 @@ type UriConstructor = new( uri: string, options?: Object ) => MwUri;
 
 interface mwHookInstance {
 	add( fn: Function ): () => void;
+	fire( fn: Function ): () => void;
 }
 
 interface MwMessage {


### PR DESCRIPTION
Add `fire` property to `mwHookInstance` interface to pre-empt TS error in Vector.

Without `fire` property:
<img width="914" alt="Screen Shot 2022-03-25 at 1 04 35 PM" src="https://user-images.githubusercontent.com/6512404/160185511-9e6f728e-0ef3-49b0-8470-860110192ba2.png">

With `fire` property:
<img width="854" alt="Screen Shot 2022-03-25 at 12 45 16 PM" src="https://user-images.githubusercontent.com/6512404/160185560-1bee5e11-96fd-4155-adbd-5b5328adf353.png">

https://phabricator.wikimedia.org/T303297