### PR TITLE
Update fire property for mwHookInstance again

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -37,7 +37,12 @@ type UriConstructor = new( uri: string, options?: Object ) => MwUri;
 
 interface mwHookInstance {
 	add( fn: Function ): () => void;
-	fire( fn: Function ): () => void;
+	/**
+	 * Fire an event for logging.
+	 *
+	 * @param [data] The data describing the event
+	 */
+	fire( data?: Record<string, unknown>|number|string ): void;
 }
 
 interface MwMessage {


### PR DESCRIPTION
Add optional data parameter to pre-empt TS error.

Without update:
<img width="884" alt="Screen Shot 2022-03-25 at 6 41 17 PM" src="https://user-images.githubusercontent.com/6512404/160217796-e40bf8a1-da1e-4af9-a220-ae190744510f.png">
<img width="941" alt="Screen Shot 2022-03-25 at 6 41 01 PM" src="https://user-images.githubusercontent.com/6512404/160217800-ed64e227-2405-46b8-a7b1-3e752f7e60cb.png">

With update:
<img width="836" alt="Screen Shot 2022-03-25 at 6 35 24 PM" src="https://user-images.githubusercontent.com/6512404/160217812-70f75306-fd7d-4fed-8d4a-57868d20edda.png">
<img width="696" alt="Screen Shot 2022-03-25 at 6 34 57 PM" src="https://user-images.githubusercontent.com/6512404/160217821-5d5434e5-f098-46b8-87b5-c7847b3a61c6.png">

https://phabricator.wikimedia.org/T303297
