### PR TITLE
Correct return type of mwHookInstance#add

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -88,7 +88,7 @@ interface MwEventLog {
 type UriConstructor = new( uri: string, options?: Object ) => MwUri;
 
 interface mwHookInstance {
-	add( fn: Function ): () => void;
+	add( fn: Function ): this;
 	/**
 	 * Fire an event for logging.
 	 *


### PR DESCRIPTION
The `add` method returns an instance of mwHookInstance ( `this` ) and not a function.

https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.base.html#mw-hook-method-add