### PR TITLE
Fix addPortletLink parameter types

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -230,8 +230,8 @@ interface MediaWiki {
 		 */
 		addPortletLink(
 			portletId: string, href: string, text: string,
-			id?: string, tooltip?: string, accesskey?: string,
-			nextnode?: HTMLElement|jQuery|string
+			id?: string|null, tooltip?: string|null, accesskey?: string|null,
+			nextnode?: HTMLElement|JQuery|string|null
 		): HTMLElement|null;
 		/**
 		 * @param {string} id of portlet

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wikimedia/types-wikimedia",
 	"author": "Wikimedia",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "TypeScript definitions for MediaWiki",
 	"main": "",
 	"repository": "github:wikimedia/typescript-types",


### PR DESCRIPTION
- Apparently optional parameters cannot be null
- Correct typo in JQuery