### PR TITLE
Add saveOptions signature to MwApi interface

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -66,6 +66,7 @@ interface MwTemplate {
 
 interface MwApi {
 	saveOption( name: string, value: unknown ): JQuery.Promise<any>;
+	saveOptions( options: Object ): JQuery.Promise<any>;
 	get( parameters: Object, ajaxOptions?: Object ): JQuery.Promise<MwApiQueryResponse|any>;
 	postWithToken( tokenType: string, params: Object, ajaxOptions?: Object ): JQuery.Promise<any>;
 }


### PR DESCRIPTION
Per https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html, this is a valid method and I am getting an error using it

Lmk if there's any additional information I should provide!