### PR TITLE
Add type for mw.errorLogger

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -190,6 +190,10 @@ interface MwLogger {
 	warn( ...args: any[] ): void;
 }
 
+interface MwErrorLogger {
+	logError( error: Error, topic?: string ): void;
+}
+
 interface MwExperimentBucket {
 	name: string,
 	enabled: boolean,
@@ -213,6 +217,7 @@ interface MediaWiki {
 	eventLog?: MwEventLog,
 	experiments: MwExperiments;
 	log: MwLogger;
+	errorLogger: MwErrorLogger;
 	util: {
 		/**
 		 * @param {string} expiry


### PR DESCRIPTION
Needed for I6622c9e5063ab387a8d6c851e0235c86a044f0a8, that is:
[Highlight existing link recommendations on article](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/GrowthExperiments/+/1084851).

Bug: T378354