### PR TITLE
feat: add basic support for TestKitchen and experiments

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="MwEcho.d.ts" />
+/// <reference path="MwTestKitchen.d.ts" />
 
 interface MwApiActionQuery {
 	action: string
@@ -223,6 +224,7 @@ interface MediaWiki {
 	storage: MwStorage,
 	echo?: MwEcho,
 	eventLog?: MwEventLog,
+	testKitchen: MwTestKitchen;
 	experiments: MwExperiments;
 	html: MwHtml;
 	log: MwLogger;

--- a/MwTestKitchen.d.ts
+++ b/MwTestKitchen.d.ts
@@ -1,0 +1,17 @@
+interface TestKitchenExperiment {
+	getAssignedGroup(): ?string;
+	isAssignedGroup( ...groups: string[] ): boolean;
+	send(
+		action: string,
+		interactionData: Record<string, unknown>,
+		contextualAttributes?: string[],
+	): void;
+	submitInteraction( action: string, interactionData: Record<string, unknown> ): void;
+	sendExposure(): void;
+	setStream( streamName: string ): this;
+	setSchema( schemaID: string ): this;
+}
+
+interface MwTestKitchen {
+	getExperiment: ( experimentName: string ) => TestKitchenExperiment;
+}


### PR DESCRIPTION
This should give us a bit of additional safety when writing instrumentation in WikimediaEvents, given that writing meaningful tests there is very tricky.