### PR TITLE
Correct MediaWiki storage definition

### DIFF
--- a/MediaWiki.d.ts
+++ b/MediaWiki.d.ts
@@ -163,12 +163,13 @@ interface MwMessage {
  */
 type MwMessageParam = string | number | HTMLElement | JQuery;
 
-interface MwStorageMap {
-	get( key: string ): string;
+interface MwStorage extends MwSafeStorage {
+    session: MwSafeStorage;
 }
 
-interface MwStorage {
-	session: MwStorageMap
+interface MwSafeStorage {
+    get( key: string ): string;
+    set( key: string, value: string, expiry?: number ): boolean;
 }
 
 interface MwClientPrefs {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wikimedia/types-wikimedia",
 	"author": "Wikimedia",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "TypeScript definitions for MediaWiki",
 	"main": "",
 	"repository": "github:wikimedia/typescript-types",


### PR DESCRIPTION
Use SafeStorage as thats what it is caused in mediawiki. Make sure mw.storage.get can be used in addition to mw.storage.session.get